### PR TITLE
feat(ingestion): make code ingestion SDK-version-aware and quality-filtered

### DIFF
--- a/src/ingestion/README.md
+++ b/src/ingestion/README.md
@@ -30,12 +30,34 @@ Each job saves JSON under `data/` (created on first run) and appends run details
 | `data_github_issues_ingestion.py` | Stylus GitHub issues and comments | `data/github_issues_sectioned.json` |
 | `data_documentation_ingestion.py` | Official Arbitrum Stylus docs + by-example pages | `data/stylus_docs.json` |
 | `data_openzeppelin_stylus_ingestion.py` | OpenZeppelin Contracts Stylus docs | `data/openzeppelin_stylus_docs.json` |
+| `data_openzeppelin_stylus_code_ingestion.py` | OpenZeppelin `rust-contracts-stylus` contract source (release-pinned) | `data/openzeppelin_stylus_code.json` |
 | `data_stylus_versions_ingestion.py` | `stylus-sdk-rs` changelog and recent merged PRs | `data/stylus_versions.json` |
 | `data_stylus_course_ingestion.py` | LearnWeb3 Stylus course pages | `data/stylus_course.json` |
-| `data_stylus_framework_ingestion.py` | Stylus framework code snippets | `data/stylus_framework_code.json` |
+| `data_stylus_framework_ingestion.py` | `stylus-sdk-rs` source, last 3 minor releases side-by-side | `data/stylus_framework_code.json` |
+| `data_stylus_by_example_ingestion.py` | Stylus-by-Example repo source (examples + walkthroughs) | `data/stylus_by_example_code.json` |
 | `data_stylus_saturdays_ingestion.py` | Stylus Saturdays articles | `data/stylus_saturdays.json` |
-| `data_awesome_stylus_code_ingestion.py` | Code files referenced from the Awesome Stylus list | `data/awesome_stylus_code.json` |
+| `data_awesome_stylus_code_ingestion.py` | Quality-filtered code from repos in the Awesome Stylus list | `data/awesome_stylus_code.json` |
 | `data_stylus_saturdays_ingestion.py` | Stylus Saturdays articles (requires `playwright`) | `data/stylus_saturdays.json` |
+
+## SDK version awareness
+
+Code sources are version-anchored so retrieval can distinguish SDK versions and
+avoid surfacing deprecated APIs as current (see `code_repo_utils.py`):
+
+- The **SDK framework** job keeps the newest patch of each of the last
+  `STYLUS_SDK_KEEP_MINORS` (default 3) minor releases side-by-side — each chunk
+  stamped with its own `sdk_version`, so version-specific questions get
+  version-appropriate code. Releases that roll off the window are pruned.
+- The **OpenZeppelin contracts** job pins to the repo's latest **release tag**
+  (not moving HEAD) and stamps `metadata.sdk_version` + `released_at`.
+- **Community code** (`awesome_stylus_code`) parses each repo's `Cargo.toml`
+  `stylus-sdk` dependency and stamps `sdk_version`. Repos are quality-filtered:
+  archived repos are dropped, along with those below `AWESOME_MIN_STARS`
+  (default 2) or not pushed within `AWESOME_MAX_AGE_DAYS` (default 730); every
+  drop is logged. Only `.rs`/`.toml`/`.md` are ingested.
+- At query time (`retrieve_chroma_docs.py`) `sdk_version` is surfaced in the
+  context header and citations, and code-intent ranking prefers version-anchored
+  chunks while down-ranking pre-0.6 (and hard-skipping pre-0.4) API-era code.
 
 ## Incremental behavior
 

--- a/src/ingestion/code_repo_utils.py
+++ b/src/ingestion/code_repo_utils.py
@@ -1,0 +1,458 @@
+"""
+Shared helpers for GitHub *code* ingestion jobs (SDK framework, community
+"awesome" repos, stylus-by-example, OpenZeppelin contracts).
+
+Two responsibilities live here so every code source behaves identically:
+
+1. Fetching a repo tree and its raw files (with a size cap and text guard).
+2. SDK-version awareness — resolving the latest release tag and parsing the
+   `stylus-sdk` dependency version out of a project's ``Cargo.toml`` so each
+   ingested code chunk can be stamped with the SDK version it targets. Without
+   this, code captured at a moving ``main``/``master`` HEAD carries no version
+   identity and the assistant cannot tell 0.5-era APIs from current ones.
+
+The version *parsing* functions are pure (no network) so they are unit-testable
+without hitting GitHub; only the ``*_remote`` / release / tree helpers do IO.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+from datetime import datetime
+from typing import Callable, Dict, List, Optional
+
+import requests
+
+from basic_logs import write_ingestion_log
+from ingestion.incremental_utils import (
+    load_entries,
+    merge_entries,
+    record_ingestion_stats,
+)
+
+try:  # Python 3.11+
+    import tomllib
+except ModuleNotFoundError:  # pragma: no cover - project targets 3.12
+    tomllib = None  # type: ignore[assignment]
+
+
+DEFAULT_MAX_FILE_BYTES = 200_000
+# Dependency crate names that identify a Stylus contract project. The SDK crate
+# is the one whose version tells us which API surface the code targets.
+STYLUS_DEP_NAMES = ("stylus-sdk", "stylus_sdk")
+# Build artifacts / vendored deps that never carry useful signal.
+DEFAULT_SKIP_DIRS = ("/target/", "/node_modules/", "/.git/")
+
+
+def build_headers() -> Dict[str, str]:
+    """Standard headers, adding the GitHub token when present for rate limits."""
+    headers = {"User-Agent": "StylusRAGBot/1.0 (+https://arbitrum.io)"}
+    token = os.environ.get("GITHUB_TOKEN")
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    return headers
+
+
+# ---------------------------------------------------------------------------
+# Raw fetch helpers
+# ---------------------------------------------------------------------------
+def safe_json(url: str, headers: Dict[str, str]) -> Optional[dict]:
+    try:
+        resp = requests.get(url, headers=headers, timeout=20)
+        resp.raise_for_status()
+        return resp.json()
+    except Exception as e:  # noqa: BLE001
+        write_ingestion_log(f"[warn] JSON fetch failed {url}: {e}")
+        return None
+
+
+def fetch_text(
+    url: str, headers: Dict[str, str], max_bytes: int = DEFAULT_MAX_FILE_BYTES
+) -> Optional[str]:
+    try:
+        resp = requests.get(url, headers=headers, timeout=30)
+        resp.raise_for_status()
+        if len(resp.content) > max_bytes:
+            return None
+        return resp.text
+    except Exception as e:  # noqa: BLE001
+        write_ingestion_log(f"[warn] Failed to fetch {url}: {e}")
+        return None
+
+
+def github_tree(repo: str, ref: str, headers: Dict[str, str]) -> Optional[List[Dict]]:
+    url = f"https://api.github.com/repos/{repo}/git/trees/{ref}?recursive=1"
+    data = safe_json(url, headers)
+    if data and "tree" in data:
+        return data["tree"]
+    return None
+
+
+def choose_ref(repo: str, headers: Dict[str, str]) -> Optional[str]:
+    """Resolve a usable default branch (``main`` then ``master``)."""
+    for ref in ("main", "master"):
+        if github_tree(repo, ref, headers):
+            return ref
+    write_ingestion_log(f"[warn] Could not resolve ref for {repo}")
+    return None
+
+
+def repo_metadata(repo: str, headers: Dict[str, str]) -> Optional[Dict]:
+    """Return ``{stars, pushed_at, archived, full_name}`` or None if missing.
+
+    Used to quality-filter community repos (skip archived / stale / low-signal).
+    """
+    data = safe_json(f"https://api.github.com/repos/{repo}", headers)
+    if not data or "full_name" not in data:
+        return None
+    return {
+        "full_name": data.get("full_name", repo),
+        "stars": int(data.get("stargazers_count") or 0),
+        "pushed_at": data.get("pushed_at"),
+        "archived": bool(data.get("archived")),
+    }
+
+
+# ---------------------------------------------------------------------------
+# SDK version awareness
+# ---------------------------------------------------------------------------
+_VERSION_CORE = re.compile(r"\d+(?:\.\d+){0,2}(?:[-+.][0-9A-Za-z.]+)?")
+
+
+def normalize_version(raw: Optional[str]) -> Optional[str]:
+    """Strip caret/tilde/comparator/`v` prefixes and return the semver core.
+
+    ``"^0.6.0"`` -> ``"0.6.0"``, ``"v0.9"`` -> ``"0.9"``, ``">=0.5, <0.7"`` ->
+    ``"0.5"`` (first constraint). Returns None when no version-like token found.
+    """
+    if not raw:
+        return None
+    stripped = raw.strip().lstrip("^~=><vV ").strip()
+    match = _VERSION_CORE.match(stripped)
+    if match:
+        return match.group(0)
+    # Fall back to the first version-like token anywhere in the string.
+    match = _VERSION_CORE.search(raw)
+    return match.group(0) if match else None
+
+
+def _version_from_dep_value(value) -> Optional[str]:
+    """Extract a version from a Cargo dependency value.
+
+    Handles ``dep = "0.6"``, ``dep = { version = "0.6", ... }`` and
+    ``dep = { workspace = true }`` (returns the sentinel ``"workspace"``).
+    """
+    if isinstance(value, str):
+        return normalize_version(value)
+    if isinstance(value, dict):
+        if value.get("workspace") is True:
+            return "workspace"
+        version = value.get("version")
+        if isinstance(version, str):
+            return normalize_version(version)
+    return None
+
+
+_REGEX_DEP_LINE = re.compile(
+    r'^\s*stylus[-_]sdk\s*=\s*'
+    r'(?:"(?P<simple>[^"]+)"'  # stylus-sdk = "0.6"
+    r'|\{[^}]*\bversion\s*=\s*"(?P<detailed>[^"]+)")',  # { version = "0.6", ... }
+    re.MULTILINE,
+)
+
+
+def _regex_sdk_version(text: str) -> Optional[str]:
+    match = _REGEX_DEP_LINE.search(text)
+    if not match:
+        return None
+    return normalize_version(match.group("simple") or match.group("detailed"))
+
+
+def parse_stylus_sdk_version(cargo_toml_text: Optional[str]) -> Optional[str]:
+    """Parse the ``stylus-sdk`` dependency version from Cargo.toml text.
+
+    Checks ``[dependencies]``, ``[dev-dependencies]``, ``[build-dependencies]``
+    and ``[workspace.dependencies]``. Falls back to a line regex if the TOML is
+    malformed (or ``tomllib`` is unavailable). ``workspace = true`` references
+    are skipped since the concrete version lives in the workspace root, which is
+    tried separately via the tree scan. Returns None when nothing usable found.
+    """
+    if not cargo_toml_text:
+        return None
+
+    if tomllib is not None:
+        try:
+            data = tomllib.loads(cargo_toml_text)
+        except Exception:  # noqa: BLE001 - malformed toml -> regex fallback
+            data = None
+        if isinstance(data, dict):
+            tables = ("dependencies", "dev-dependencies", "build-dependencies")
+            for table in tables:
+                deps = data.get(table) or {}
+                for name in STYLUS_DEP_NAMES:
+                    if name in deps:
+                        version = _version_from_dep_value(deps[name])
+                        if version and version != "workspace":
+                            return version
+            workspace_deps = (data.get("workspace") or {}).get("dependencies") or {}
+            for name in STYLUS_DEP_NAMES:
+                if name in workspace_deps:
+                    version = _version_from_dep_value(workspace_deps[name])
+                    if version and version != "workspace":
+                        return version
+
+    return _regex_sdk_version(cargo_toml_text)
+
+
+def find_cargo_toml_paths(tree: List[Dict]) -> List[str]:
+    """Return Cargo.toml paths in the tree, shallowest first (root wins)."""
+    paths = [
+        node.get("path", "")
+        for node in tree
+        if node.get("type") == "blob"
+        and node.get("path", "").rsplit("/", 1)[-1] == "Cargo.toml"
+    ]
+    paths.sort(key=lambda p: (p.count("/"), len(p)))
+    return paths
+
+
+def detect_sdk_version(
+    repo: str,
+    ref: str,
+    tree: List[Dict],
+    headers: Dict[str, str],
+    *,
+    max_manifests: int = 5,
+    fetcher: Optional[Callable[[str], Optional[str]]] = None,
+) -> Optional[str]:
+    """Best-effort ``stylus-sdk`` version for a repo at ``ref``.
+
+    Scans up to ``max_manifests`` Cargo.toml files (root first) and returns the
+    first parseable ``stylus-sdk`` version. ``fetcher`` is injectable for tests.
+    """
+    fetch = fetcher or (lambda url: fetch_text(url, headers))
+    for path in find_cargo_toml_paths(tree)[:max_manifests]:
+        raw_url = f"https://raw.githubusercontent.com/{repo}/{ref}/{path}"
+        text = fetch(raw_url)
+        version = parse_stylus_sdk_version(text) if text else None
+        if version:
+            return version
+    return None
+
+
+def _semver_key(tag: str):
+    core = normalize_version(tag)
+    if not core:
+        return None
+    nums = re.findall(r"\d+", core.split("-")[0])
+    return tuple(int(n) for n in nums) if nums else None
+
+
+def latest_release(repo: str, headers: Dict[str, str]) -> Optional[Dict]:
+    """Resolve the latest release: ``{tag, published_at}`` or None.
+
+    Prefers the GitHub "latest release" endpoint; falls back to the highest
+    semver-looking tag. Lets a code source pin to a released version instead of
+    a moving HEAD so its chunks carry a real ``sdk_version``.
+    """
+    data = safe_json(f"https://api.github.com/repos/{repo}/releases/latest", headers)
+    if data and data.get("tag_name"):
+        return {"tag": data["tag_name"], "published_at": data.get("published_at")}
+
+    tags = safe_json(f"https://api.github.com/repos/{repo}/tags?per_page=30", headers)
+    if isinstance(tags, list):
+        best_key = None
+        best_tag = None
+        for entry in tags:
+            name = entry.get("name", "")
+            key = _semver_key(name)
+            if key and (best_key is None or key > best_key):
+                best_key = key
+                best_tag = name
+        if best_tag:
+            return {"tag": best_tag, "published_at": None}
+    return None
+
+
+def _top_minor_tags(tags: List[str], count: int) -> List[str]:
+    """Newest tag within each of the top ``count`` minor lines, newest minor first.
+
+    Pure/testable. Groups tags by (major, minor) and keeps the highest patch in
+    each group, e.g. from [0.10.8, 0.10.7, 0.9.0, 0.8.4, 0.8.3] with count=3 ->
+    [0.10.8, 0.9.0, 0.8.4].
+    """
+    best: Dict[tuple, tuple] = {}  # (major, minor) -> (full_key, tag)
+    for tag in tags:
+        key = _semver_key(tag)
+        if not key:
+            continue
+        minor = key[:2]
+        if minor not in best or key > best[minor][0]:
+            best[minor] = (key, tag)
+    top_minors = sorted(best.keys(), reverse=True)[: max(count, 0)]
+    return [best[minor][1] for minor in top_minors]
+
+
+def latest_minor_releases(
+    repo: str, headers: Dict[str, str], count: int = 3
+) -> List[Dict]:
+    """Resolve the newest patch of each of the last ``count`` minor releases.
+
+    Returns ``[{tag, published_at, sdk_version}]`` newest-minor first. Lets a
+    source keep several SDK versions side-by-side so version-specific questions
+    ("how did storage work in 0.8?") have version-appropriate material, each
+    chunk stamped with its own ``sdk_version``.
+    """
+    tags: List[str] = []
+    published: Dict[str, Optional[str]] = {}
+
+    releases = safe_json(
+        f"https://api.github.com/repos/{repo}/releases?per_page=100", headers
+    )
+    if isinstance(releases, list):
+        for entry in releases:
+            tag = entry.get("tag_name")
+            if tag:
+                tags.append(tag)
+                published[tag] = entry.get("published_at")
+
+    tag_list = safe_json(f"https://api.github.com/repos/{repo}/tags?per_page=100", headers)
+    if isinstance(tag_list, list):
+        tags.extend(entry.get("name") for entry in tag_list if entry.get("name"))
+
+    selected = _top_minor_tags(tags, count)
+    return [
+        {
+            "tag": tag,
+            "published_at": published.get(tag),
+            "sdk_version": normalize_version(tag),
+        }
+        for tag in selected
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Generic code collection + save
+# ---------------------------------------------------------------------------
+def collect_repo_code_entries(
+    repo: str,
+    *,
+    source: str,
+    allowed_extensions: tuple,
+    headers: Dict[str, str],
+    ref: Optional[str] = None,
+    sdk_version: Optional[str] = None,
+    released_at: Optional[str] = None,
+    extra_meta: Optional[Dict] = None,
+    skip_dirs: tuple = DEFAULT_SKIP_DIRS,
+    max_file_bytes: int = DEFAULT_MAX_FILE_BYTES,
+) -> List[Dict]:
+    """Fetch code files from a repo and build version-stamped RAG entries.
+
+    Resolves ``ref`` (default branch) and ``sdk_version`` (from Cargo.toml) when
+    not supplied. Every entry's metadata carries ``sdk_version`` when known so
+    retrieval can distinguish/rank by SDK version.
+    """
+    if ref is None:
+        ref = choose_ref(repo, headers)
+        if not ref:
+            return []
+
+    tree = github_tree(repo, ref, headers)
+    if tree is None:
+        return []
+
+    if sdk_version is None:
+        sdk_version = detect_sdk_version(repo, ref, tree, headers)
+
+    now_iso = datetime.utcnow().isoformat() + "Z"
+    entries: List[Dict] = []
+    for node in tree:
+        if node.get("type") != "blob":
+            continue
+        path = node.get("path", "")
+        low = path.lower()
+        if any(skip in f"/{low}/" for skip in skip_dirs):
+            continue
+        if not low.endswith(allowed_extensions):
+            continue
+
+        raw_url = f"https://raw.githubusercontent.com/{repo}/{ref}/{path}"
+        content = fetch_text(raw_url, headers, max_bytes=max_file_bytes)
+        if not content:
+            continue
+
+        metadata: Dict = {
+            "source": source,
+            "repo": repo,
+            "ref": ref,
+            "path": path,
+            "url": raw_url,
+            "ingested_at": now_iso,
+        }
+        # Only set keys with real values — Chroma rejects None metadata values.
+        if sdk_version:
+            metadata["sdk_version"] = sdk_version
+        if released_at:
+            metadata["released_at"] = released_at
+        if extra_meta:
+            metadata.update({k: v for k, v in extra_meta.items() if v is not None})
+
+        entries.append({"text": content, "metadata": metadata})
+
+    version_note = f" (sdk {sdk_version})" if sdk_version else ""
+    write_ingestion_log(f"[ok] Collected {len(entries)} files from {repo}@{ref}{version_note}")
+    return entries
+
+
+def save_code_entries(
+    output_path: str,
+    entries: List[Dict],
+    job_name: str,
+    *,
+    multi_version: bool = False,
+    keep_refs: Optional[set] = None,
+) -> List[Dict]:
+    """Merge code entries into their JSON file and record run stats.
+
+    Single-version (default) uses a (repo, path) merge key so re-pinning a source
+    to a new tag replaces its files in place. ``multi_version=True`` keys on
+    (repo, ref, path) so several release tags of the same repo coexist. When
+    ``keep_refs`` is given, merged entries whose ``ref`` is outside that set are
+    pruned — this enforces a sliding window (e.g. only the last 3 minors) while
+    still carrying forward a version that was merely unreachable on this run
+    (its ref stays in ``keep_refs``).
+    """
+    if multi_version:
+        def key_fn(e):
+            meta = e.get("metadata", {})
+            return (meta.get("repo"), meta.get("ref"), meta.get("path"))
+    else:
+        def key_fn(e):
+            meta = e.get("metadata", {})
+            return (meta.get("repo"), meta.get("path"))
+
+    existing = load_entries(output_path)
+    merged, stats = merge_entries(existing, entries, key_fn=key_fn)
+
+    if keep_refs is not None:
+        before = len(merged)
+        merged = [e for e in merged if e.get("metadata", {}).get("ref") in keep_refs]
+        pruned = before - len(merged)
+        if pruned:
+            write_ingestion_log(
+                f"[info] {job_name}: pruned {pruned} entries outside pinned refs {sorted(keep_refs)}"
+            )
+
+    os.makedirs(os.path.dirname(output_path), exist_ok=True)
+    with open(output_path, "w", encoding="utf-8") as f:
+        json.dump(merged, f, ensure_ascii=False, indent=2)
+    write_ingestion_log(
+        f"[ok] {job_name}: saved {len(merged)} entries (added {stats['added']}, "
+        f"updated {stats['updated']}, unchanged {stats['unchanged']}, "
+        f"retained {stats['retained']}) to {output_path}"
+    )
+    record_ingestion_stats(job_name, stats)
+    return merged

--- a/src/ingestion/data_awesome_stylus_code_ingestion.py
+++ b/src/ingestion/data_awesome_stylus_code_ingestion.py
@@ -1,12 +1,18 @@
 """
 Ingest code from community projects referenced in the awesome-stylus list.
+
+Quality-filtered: archived repos are skipped, along with repos below a star
+floor or not pushed within a staleness window (all env-overridable, and every
+drop is logged rather than silently swallowed). Ingestion is restricted to
+Rust-relevant files, and each repo's ``stylus-sdk`` version is stamped onto its
+chunks so version-mismatched community code can be told apart at retrieval.
+
 Outputs: data/awesome_stylus_code.json
 """
 
-import json
 import os
 import re
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Dict, List, Optional
 
 import requests
@@ -14,18 +20,20 @@ from dotenv import load_dotenv
 
 from basic_logs import write_ingestion_log
 from ingestion.incremental_utils import (
-    load_entries,
-    merge_entries,
     record_ingestion_stats,
     should_skip_ingestion,
+)
+from ingestion.code_repo_utils import (
+    build_headers,
+    collect_repo_code_entries,
+    fetch_text,
+    repo_metadata,
+    save_code_entries,
 )
 
 load_dotenv()
 
-HEADERS = {"User-Agent": "StylusRAGBot/1.0 (+https://arbitrum.io)"}
-token = os.environ.get("GITHUB_TOKEN")
-if token:
-    HEADERS["Authorization"] = f"Bearer {token}"
+HEADERS = build_headers()
 
 AWESOME_REPO = "OffchainLabs/awesome-stylus"
 # GitHub API raw endpoint gives canonical markdown, avoiding HTML placeholders
@@ -34,79 +42,17 @@ AWESOME_README_API = "https://api.github.com/repos/OffchainLabs/awesome-stylus/c
 OUTPUT_JSON_PATH = "data/awesome_stylus_code.json"
 JOB_NAME = "awesome_stylus_code"
 
-ALLOWED_EXTENSIONS = (
-    ".rs",
-    ".toml",
-    ".md",
-    ".yaml",
-    ".yml",
-    ".json",
-    ".js",
-    ".jsx",
-    ".ts",
-    ".tsx",
-    ".py",
-)
-MAX_FILE_BYTES = 200_000
+# Rust-relevant only: community frontend (.js/.ts/.py) added noise without
+# helping Stylus *contract* answers. README/markdown kept for project context.
+ALLOWED_EXTENSIONS = (".rs", ".toml", ".md")
 
-
-def safe_json(url: str) -> Optional[dict]:
-    try:
-        resp = requests.get(url, headers=HEADERS, timeout=20)
-        resp.raise_for_status()
-        return resp.json()
-    except Exception as e:
-        write_ingestion_log(f"[warn] JSON fetch failed {url}: {e}")
-        return None
-
-
-def fetch_text(url: str, extra_headers: Optional[Dict] = None) -> Optional[str]:
-    try:
-        headers = HEADERS.copy()
-        if extra_headers:
-            headers.update(extra_headers)
-        resp = requests.get(url, headers=headers, timeout=30)
-        resp.raise_for_status()
-        if len(resp.content) > MAX_FILE_BYTES:
-            return None
-        return resp.text
-    except Exception as e:
-        write_ingestion_log(f"[warn] Failed to fetch {url}: {e}")
-        return None
-
-
-def github_tree(repo: str, ref: str) -> Optional[List[Dict]]:
-    url = f"https://api.github.com/repos/{repo}/git/trees/{ref}?recursive=1"
-    data = safe_json(url)
-    if data and "tree" in data:
-        return data["tree"]
-    return None
-
-
-def choose_ref(repo: str) -> Optional[str]:
-    for ref in ["main", "master"]:
-        if github_tree(repo, ref):
-            return ref
-    write_ingestion_log(f"[warn] Could not resolve ref for {repo}")
-    return None
-
-
-def repo_exists(repo: str) -> bool:
-    url = f"https://api.github.com/repos/{repo}"
-    resp = requests.get(url, headers=HEADERS, timeout=10)
-    if resp.status_code == 200:
-        return True
-    if resp.status_code == 404:
-        return False
-    # For other errors, assume not usable to avoid repeated failures
-    return False
+# Quality gates (env-overridable; lenient defaults so we filter noise, not signal).
+MIN_STARS = int(os.getenv("AWESOME_MIN_STARS", "2"))
+MAX_AGE_DAYS = int(os.getenv("AWESOME_MAX_AGE_DAYS", "730"))  # ~2 years
 
 
 def search_repo(owner: str, repo_prefix: str) -> Optional[str]:
-    """
-    Try to find the full repo name via GitHub search when the extracted slug fails.
-    Returns full_name (owner/name) or None.
-    """
+    """Find the full repo name via GitHub search when the extracted slug fails."""
     query = f"{repo_prefix} in:name user:{owner}"
     url = f"https://api.github.com/search/repositories?q={requests.utils.quote(query)}&per_page=1"
     try:
@@ -115,7 +61,7 @@ def search_repo(owner: str, repo_prefix: str) -> Optional[str]:
         items = resp.json().get("items", [])
         if items:
             return items[0]["full_name"]
-    except Exception as e:
+    except Exception as e:  # noqa: BLE001
         write_ingestion_log(f"[info] search repo failed for {owner}/{repo_prefix}: {e}")
     return None
 
@@ -123,13 +69,7 @@ def search_repo(owner: str, repo_prefix: str) -> Optional[str]:
 def extract_repo_links_from_markdown(md: str) -> List[str]:
     """
     Extract repo slugs from GitHub links in the README.
-    Sources parsed:
-      - Markdown links: [text](href)
-      - Plain URLs in text
-    Supports:
-      - https://github.com/owner/repo/...
-      - https://raw.githubusercontent.com/owner/repo/branch/path
-      - /owner/repo or owner/repo inside markdown href
+    Supports markdown links, plain URLs, github.com and raw.githubusercontent.com.
     """
     repos = set()
 
@@ -137,36 +77,27 @@ def extract_repo_links_from_markdown(md: str) -> List[str]:
         return bool(re.match(r"^[A-Za-z0-9_.-]+$", part))
 
     hrefs = set()
-    # 1) Markdown links
     for m in re.finditer(r"\[[^\]]*\]\(([^)]+)\)", md):
         hrefs.add(m.group(1))
-    # 2) Plain URLs
     for url in re.findall(r"https?://[^\s)]+", md):
         hrefs.add(url)
 
     for url in hrefs:
-        # normalize relative or owner/repo hrefs
         if url.startswith("/"):
             url = f"https://github.com{url}"
         elif re.match(r"^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+", url):
             url = f"https://github.com/{url}"
 
-        # strip trailing punctuation
         url = url.rstrip(").,`>\"'")
         try:
             parsed = requests.utils.urlparse(url)
-        except Exception:
+        except Exception:  # noqa: BLE001
             continue
         netloc = parsed.netloc.lower()
         path_parts = parsed.path.strip("/").split("/")
-        if netloc.endswith("github.com"):
+        if netloc.endswith("github.com") or netloc.endswith("raw.githubusercontent.com"):
             if len(path_parts) >= 2 and valid_part(path_parts[0]) and valid_part(path_parts[1]):
-                slug = f"{path_parts[0]}/{path_parts[1]}"
-                repos.add(slug)
-        elif netloc.endswith("raw.githubusercontent.com"):
-            if len(path_parts) >= 2 and valid_part(path_parts[0]) and valid_part(path_parts[1]):
-                slug = f"{path_parts[0]}/{path_parts[1]}"
-                repos.add(slug)
+                repos.add(f"{path_parts[0]}/{path_parts[1]}")
 
     cleaned = set()
     for r in repos:
@@ -179,64 +110,67 @@ def extract_repo_links_from_markdown(md: str) -> List[str]:
             continue
         cleaned.add(r)
 
-    repos = cleaned
-    return sorted(repos)
+    return sorted(cleaned)
 
 
-def build_entry(repo: str, ref: str, path: str, text: str) -> Dict:
-    now_iso = datetime.utcnow().isoformat() + "Z"
-    raw_url = f"https://raw.githubusercontent.com/{repo}/{ref}/{path}"
-    return {
-        "text": text,
-        "metadata": {
-            "source": "awesome_stylus_code",
-            "repo": repo,
-            "ref": ref,
-            "path": path,
-            "url": raw_url,
-            "ingested_at": now_iso,
-        },
-    }
+def _is_stale(pushed_at: Optional[str]) -> bool:
+    """True if the repo hasn't been pushed within MAX_AGE_DAYS."""
+    if MAX_AGE_DAYS <= 0 or not pushed_at:
+        return False
+    try:
+        pushed = datetime.fromisoformat(pushed_at.replace("Z", "+00:00"))
+    except ValueError:
+        return False
+    age_days = (datetime.now(timezone.utc) - pushed).days
+    return age_days > MAX_AGE_DAYS
+
+
+def _passes_quality_gate(repo: str) -> Optional[Dict]:
+    """Return repo metadata if the repo clears the quality gates, else None.
+
+    Every rejection is logged so a shrinking corpus is visible, not silent.
+    """
+    meta = repo_metadata(repo, HEADERS)
+    if meta is None:
+        # Try a search fallback for a moved/renamed slug before giving up.
+        owner, name = repo.split("/", 1)
+        suggestion = search_repo(owner, name)
+        if suggestion:
+            meta = repo_metadata(suggestion, HEADERS)
+        if meta is None:
+            write_ingestion_log(f"[skip] {repo}: not found or inaccessible")
+            return None
+
+    if meta["archived"]:
+        write_ingestion_log(f"[skip] {meta['full_name']}: archived")
+        return None
+    if meta["stars"] < MIN_STARS:
+        write_ingestion_log(
+            f"[skip] {meta['full_name']}: {meta['stars']} stars < min {MIN_STARS}"
+        )
+        return None
+    if _is_stale(meta["pushed_at"]):
+        write_ingestion_log(
+            f"[skip] {meta['full_name']}: stale (last push {meta['pushed_at']})"
+        )
+        return None
+    return meta
 
 
 def collect_repo_files(repo: str) -> List[Dict]:
-    if not repo_exists(repo):
-        owner, name = repo.split("/", 1)
-        suggestion = search_repo(owner, name)
-        if suggestion and repo_exists(suggestion):
-            write_ingestion_log(f"[info] Resolved {repo} -> {suggestion} via search")
-            repo = suggestion
-        else:
-            write_ingestion_log(f"[warn] Repo not found or inaccessible: {repo}")
-            return []
-
-    ref = choose_ref(repo)
-    if not ref:
+    meta = _passes_quality_gate(repo)
+    if meta is None:
         return []
 
-    tree = github_tree(repo, ref)
-    if tree is None:
-        return []
-
-    entries: List[Dict] = []
-    for node in tree:
-        if node.get("type") != "blob":
-            continue
-        path = node.get("path", "")
-        if "/node_modules/" in f"/{path}/":
-            continue
-        if not path.lower().endswith(ALLOWED_EXTENSIONS):
-            continue
-
-        raw_url = f"https://raw.githubusercontent.com/{repo}/{ref}/{path}"
-        content = fetch_text(raw_url)
-        if not content:
-            continue
-
-        entries.append(build_entry(repo, ref, path, content))
-
-    write_ingestion_log(f"[ok] Collected {len(entries)} files from {repo}")
-    return entries
+    resolved = meta["full_name"]
+    return collect_repo_code_entries(
+        resolved,
+        source="awesome_stylus_code",
+        allowed_extensions=ALLOWED_EXTENSIONS,
+        headers=HEADERS,
+        released_at=meta.get("pushed_at"),
+        extra_meta={"stars": meta["stars"], "pushed_at": meta.get("pushed_at")},
+    )
 
 
 def ingest_awesome_stylus_code(force_refresh: bool = False):
@@ -248,7 +182,7 @@ def ingest_awesome_stylus_code(force_refresh: bool = False):
     entries: List[Dict] = []
     readme = fetch_text(
         AWESOME_README_API,
-        extra_headers={"Accept": "application/vnd.github.v3.raw"},
+        {**HEADERS, "Accept": "application/vnd.github.v3.raw"},
     )
     if not readme:
         write_ingestion_log("[warn] Could not fetch awesome-stylus README; skipping")
@@ -256,27 +190,13 @@ def ingest_awesome_stylus_code(force_refresh: bool = False):
         repo_slugs = extract_repo_links_from_markdown(readme)
         if not repo_slugs:
             write_ingestion_log("[warn] No repo links detected in README")
+        write_ingestion_log(
+            f"[info] {len(repo_slugs)} candidate repos (min_stars={MIN_STARS}, max_age_days={MAX_AGE_DAYS})"
+        )
         for repo in repo_slugs:
             entries.extend(collect_repo_files(repo))
 
-    existing = load_entries(OUTPUT_JSON_PATH)
-    merged, stats = merge_entries(
-        existing,
-        entries,
-        key_fn=lambda e: (
-            e.get("metadata", {}).get("repo"),
-            e.get("metadata", {}).get("path"),
-        ),
-    )
-
-    os.makedirs(os.path.dirname(OUTPUT_JSON_PATH), exist_ok=True)
-    with open(OUTPUT_JSON_PATH, "w", encoding="utf-8") as f:
-        json.dump(merged, f, ensure_ascii=False, indent=2)
-
-    write_ingestion_log(
-        f"[ok] Saved {len(merged)} community code entries (added {stats['added']}, updated {stats['updated']}, unchanged {stats['unchanged']}, retained {stats['retained']}) to {OUTPUT_JSON_PATH}"
-    )
-    record_ingestion_stats(JOB_NAME, stats)
+    merged = save_code_entries(OUTPUT_JSON_PATH, entries, JOB_NAME)
     return len(merged)
 
 

--- a/src/ingestion/data_openzeppelin_stylus_code_ingestion.py
+++ b/src/ingestion/data_openzeppelin_stylus_code_ingestion.py
@@ -1,0 +1,68 @@
+"""
+Ingest the OpenZeppelin Stylus contracts *source* (OpenZeppelin/rust-contracts-stylus).
+
+Complements the OZ *docs* crawler with the actual, version-tagged contract
+implementations. Pins to the latest release tag so the ingested code matches a
+published crate version and stamps ``sdk_version`` for version-aware retrieval.
+
+Outputs: data/openzeppelin_stylus_code.json
+"""
+
+from typing import List, Dict
+
+from dotenv import load_dotenv
+
+from basic_logs import write_ingestion_log
+from ingestion.incremental_utils import (
+    record_ingestion_stats,
+    should_skip_ingestion,
+)
+from ingestion.code_repo_utils import (
+    build_headers,
+    collect_repo_code_entries,
+    latest_release,
+    save_code_entries,
+)
+
+load_dotenv()
+
+HEADERS = build_headers()
+
+REPO = "OpenZeppelin/rust-contracts-stylus"
+OUTPUT_JSON_PATH = "data/openzeppelin_stylus_code.json"
+JOB_NAME = "openzeppelin_stylus_code"
+
+ALLOWED_EXTENSIONS = (".rs", ".toml", ".md")
+
+
+def ingest_openzeppelin_stylus_code(force_refresh: bool = False):
+    if should_skip_ingestion(JOB_NAME, force_refresh=force_refresh):
+        write_ingestion_log(f"[skip] {JOB_NAME}: previous run had no changes; use --force-refresh to override")
+        record_ingestion_stats(JOB_NAME, {"added": 0, "updated": 0, "unchanged": 0, "retained": 0}, skipped=True)
+        return 0
+
+    release = latest_release(REPO, HEADERS)
+    if release:
+        ref = release["tag"]
+        released_at = release.get("published_at")
+        write_ingestion_log(f"[info] Pinning {REPO} to release {ref}")
+    else:
+        ref = None  # collector falls back to default branch
+        released_at = None
+        write_ingestion_log(f"[warn] No release/tag resolved for {REPO}; using default branch HEAD")
+
+    # sdk_version left None -> collector detects it from the repo's Cargo.toml.
+    entries: List[Dict] = collect_repo_code_entries(
+        REPO,
+        source="openzeppelin_stylus_code",
+        allowed_extensions=ALLOWED_EXTENSIONS,
+        headers=HEADERS,
+        ref=ref,
+        released_at=released_at,
+    )
+    merged = save_code_entries(OUTPUT_JSON_PATH, entries, JOB_NAME)
+    return len(merged)
+
+
+if __name__ == "__main__":
+    ingest_openzeppelin_stylus_code()

--- a/src/ingestion/data_stylus_by_example_ingestion.py
+++ b/src/ingestion/data_stylus_by_example_ingestion.py
@@ -1,0 +1,55 @@
+"""
+Ingest the source of the Stylus-by-Example repo (contract examples + prose).
+
+The rendered pages are already partially covered by the docs ingestion via a
+hardcoded URL list; ingesting the repo captures the raw example source, auto-
+tracks newly added examples, and stamps the SDK version the examples target.
+
+Outputs: data/stylus_by_example_code.json
+"""
+
+from typing import List, Dict
+
+from dotenv import load_dotenv
+
+from basic_logs import write_ingestion_log
+from ingestion.incremental_utils import (
+    record_ingestion_stats,
+    should_skip_ingestion,
+)
+from ingestion.code_repo_utils import (
+    build_headers,
+    collect_repo_code_entries,
+    save_code_entries,
+)
+
+load_dotenv()
+
+HEADERS = build_headers()
+
+REPO = "OffchainLabs/stylus-by-example"
+OUTPUT_JSON_PATH = "data/stylus_by_example_code.json"
+JOB_NAME = "stylus_by_example"
+
+# .mdx captures the example walkthroughs; .rs/.toml the runnable contract source.
+ALLOWED_EXTENSIONS = (".rs", ".toml", ".md", ".mdx")
+
+
+def ingest_stylus_by_example(force_refresh: bool = False):
+    if should_skip_ingestion(JOB_NAME, force_refresh=force_refresh):
+        write_ingestion_log(f"[skip] {JOB_NAME}: previous run had no changes; use --force-refresh to override")
+        record_ingestion_stats(JOB_NAME, {"added": 0, "updated": 0, "unchanged": 0, "retained": 0}, skipped=True)
+        return 0
+
+    entries: List[Dict] = collect_repo_code_entries(
+        REPO,
+        source="stylus_by_example_code",
+        allowed_extensions=ALLOWED_EXTENSIONS,
+        headers=HEADERS,
+    )
+    merged = save_code_entries(OUTPUT_JSON_PATH, entries, JOB_NAME)
+    return len(merged)
+
+
+if __name__ == "__main__":
+    ingest_stylus_by_example()

--- a/src/ingestion/data_stylus_framework_ingestion.py
+++ b/src/ingestion/data_stylus_framework_ingestion.py
@@ -1,126 +1,87 @@
 """
-Ingest the Stylus Rust SDK (bast framework) codebase for RAG.
+Ingest the Stylus Rust SDK (base framework) codebase for RAG.
+
+Pins to the newest patch of each of the last ``STYLUS_SDK_KEEP_MINORS`` (default
+3) minor releases of ``stylus-sdk-rs`` — kept side-by-side, each chunk stamped
+with its own ``sdk_version`` — so version-specific questions ("how did storage
+work in 0.8?") have version-appropriate material instead of only current HEAD.
+Versions that roll off the window are pruned. Falls back to the default branch
+(marked ``unreleased``) when no release/tag can be resolved.
+
 Outputs: data/stylus_framework_code.json
 """
 
-import json
 import os
-from datetime import datetime
-from typing import Dict, List, Optional
+from typing import List, Dict, Set, Tuple
 
-import requests
 from dotenv import load_dotenv
 
 from basic_logs import write_ingestion_log
 from ingestion.incremental_utils import (
-    load_entries,
-    merge_entries,
     record_ingestion_stats,
     should_skip_ingestion,
+)
+from ingestion.code_repo_utils import (
+    build_headers,
+    collect_repo_code_entries,
+    latest_minor_releases,
+    save_code_entries,
 )
 
 load_dotenv()
 
-HEADERS = {"User-Agent": "StylusRAGBot/1.0 (+https://arbitrum.io)"}
-token = os.environ.get("GITHUB_TOKEN")
-if token:
-    HEADERS["Authorization"] = f"Bearer {token}"
+HEADERS = build_headers()
 
 FRAMEWORK_REPO = "OffchainLabs/stylus-sdk-rs"
 OUTPUT_JSON_PATH = "data/stylus_framework_code.json"
 JOB_NAME = "stylus_framework"
 
-ALLOWED_EXTENSIONS = (
-    ".rs",
-    ".toml",
-    ".md",
-    ".yaml",
-    ".yml",
-    ".json",
-)
-MAX_FILE_BYTES = 200_000
+ALLOWED_EXTENSIONS = (".rs", ".toml", ".md", ".yaml", ".yml", ".json")
+# How many recent minor release lines to keep indexed side-by-side.
+KEEP_MINORS = int(os.getenv("STYLUS_SDK_KEEP_MINORS", "3"))
 
 
-def safe_json(url: str) -> Optional[dict]:
-    try:
-        resp = requests.get(url, headers=HEADERS, timeout=20)
-        resp.raise_for_status()
-        return resp.json()
-    except Exception as e:
-        write_ingestion_log(f"[warn] JSON fetch failed {url}: {e}")
-        return None
+def collect_framework_files() -> Tuple[List[Dict], Set[str]]:
+    """Collect SDK source across the last KEEP_MINORS minor releases.
 
+    For the SDK repo itself the release tag *is* the SDK version, so
+    ``sdk_version`` comes from the tag. Returns (entries, pinned_refs) so the
+    caller can prune versions that have rolled off the window.
+    """
+    releases = latest_minor_releases(FRAMEWORK_REPO, HEADERS, count=KEEP_MINORS)
+    if not releases:
+        write_ingestion_log(
+            f"[warn] No releases resolved for {FRAMEWORK_REPO}; using default branch HEAD"
+        )
+        entries = collect_repo_code_entries(
+            FRAMEWORK_REPO,
+            source="stylus_framework_code",
+            allowed_extensions=ALLOWED_EXTENSIONS,
+            headers=HEADERS,
+            sdk_version="unreleased",
+        )
+        return entries, set()
 
-def fetch_text(url: str) -> Optional[str]:
-    try:
-        resp = requests.get(url, headers=HEADERS, timeout=30)
-        resp.raise_for_status()
-        if len(resp.content) > MAX_FILE_BYTES:
-            return None
-        return resp.text
-    except Exception as e:
-        write_ingestion_log(f"[warn] Failed to fetch {url}: {e}")
-        return None
-
-
-def github_tree(repo: str, ref: str) -> Optional[List[Dict]]:
-    url = f"https://api.github.com/repos/{repo}/git/trees/{ref}?recursive=1"
-    data = safe_json(url)
-    if data and "tree" in data:
-        return data["tree"]
-    return None
-
-
-def choose_ref(repo: str) -> Optional[str]:
-    for ref in ["main", "master"]:
-        if github_tree(repo, ref):
-            return ref
-    write_ingestion_log(f"[warn] Could not resolve ref for {repo}")
-    return None
-
-
-def build_entry(repo: str, ref: str, path: str, text: str) -> Dict:
-    now_iso = datetime.utcnow().isoformat() + "Z"
-    raw_url = f"https://raw.githubusercontent.com/{repo}/{ref}/{path}"
-    return {
-        "text": text,
-        "metadata": {
-            "source": "stylus_framework_code",
-            "repo": repo,
-            "ref": ref,
-            "path": path,
-            "url": raw_url,
-            "ingested_at": now_iso,
-        },
-    }
-
-
-def collect_framework_files() -> List[Dict]:
-    ref = choose_ref(FRAMEWORK_REPO)
-    if not ref:
-        return []
-
-    tree = github_tree(FRAMEWORK_REPO, ref)
-    if tree is None:
-        return []
+    pinned = ", ".join(r["tag"] for r in releases)
+    write_ingestion_log(f"[info] Pinning {FRAMEWORK_REPO} to releases: {pinned}")
 
     entries: List[Dict] = []
-    for node in tree:
-        if node.get("type") != "blob":
-            continue
-        path = node.get("path", "")
-        if not path.lower().endswith(ALLOWED_EXTENSIONS):
-            continue
-
-        raw_url = f"https://raw.githubusercontent.com/{FRAMEWORK_REPO}/{ref}/{path}"
-        content = fetch_text(raw_url)
-        if not content:
-            continue
-
-        entries.append(build_entry(FRAMEWORK_REPO, ref, path, content))
-
-    write_ingestion_log(f"[ok] Collected {len(entries)} framework files")
-    return entries
+    keep_refs: Set[str] = set()
+    for release in releases:
+        ref = release["tag"]
+        keep_refs.add(ref)
+        entries.extend(
+            collect_repo_code_entries(
+                FRAMEWORK_REPO,
+                source="stylus_framework_code",
+                allowed_extensions=ALLOWED_EXTENSIONS,
+                headers=HEADERS,
+                ref=ref,
+                sdk_version=release["sdk_version"],
+                released_at=release.get("published_at"),
+            )
+        )
+    return entries, keep_refs
 
 
 def ingest_stylus_framework(force_refresh: bool = False):
@@ -129,18 +90,14 @@ def ingest_stylus_framework(force_refresh: bool = False):
         record_ingestion_stats(JOB_NAME, {"added": 0, "updated": 0, "unchanged": 0, "retained": 0}, skipped=True)
         return 0
 
-    entries = collect_framework_files()
-    existing = load_entries(OUTPUT_JSON_PATH)
-    merged, stats = merge_entries(
-        existing, entries, key_fn=lambda e: (e.get("metadata", {}).get("repo"), e.get("metadata", {}).get("path"))
+    entries, keep_refs = collect_framework_files()
+    merged = save_code_entries(
+        OUTPUT_JSON_PATH,
+        entries,
+        JOB_NAME,
+        multi_version=bool(keep_refs),
+        keep_refs=keep_refs or None,
     )
-    os.makedirs(os.path.dirname(OUTPUT_JSON_PATH), exist_ok=True)
-    with open(OUTPUT_JSON_PATH, "w", encoding="utf-8") as f:
-        json.dump(merged, f, ensure_ascii=False, indent=2)
-    write_ingestion_log(
-        f"[ok] Saved {len(merged)} framework code entries (added {stats['added']}, updated {stats['updated']}, unchanged {stats['unchanged']}, retained {stats['retained']}) to {OUTPUT_JSON_PATH}"
-    )
-    record_ingestion_stats(JOB_NAME, stats)
     return len(merged)
 
 

--- a/src/retrieve_chroma_docs.py
+++ b/src/retrieve_chroma_docs.py
@@ -107,6 +107,19 @@ PORTING_CANONICAL_REFERENCES = [
 ]
 
 LEGACY_EXAMPLE_VERSION_PATTERN = re.compile(r"v0\.[0-3]\.x")
+
+
+def _sdk_version_tuple(version):
+    """Comparable numeric tuple for an ``sdk_version`` metadata string.
+
+    ``"0.9.0"`` -> ``(0, 9, 0)``; ``"unreleased"``/``None`` -> ``None`` (no
+    opinion). Lets ranking prefer version-anchored code and down-rank the
+    pre-``#[public]`` legacy API era without a brittle text regex.
+    """
+    if not version:
+        return None
+    nums = re.findall(r"\d+", str(version).split("-")[0])
+    return tuple(int(n) for n in nums) if nums else None
 REFERENCE_TOKEN_STOPWORDS = {
     "and",
     "the",
@@ -177,6 +190,7 @@ def format_chunk_with_metadata(hit: dict) -> str:
     section = meta.get("section") or meta.get("category") or ""
     subsection = meta.get("subsection") or ""
     source = meta.get("source") or ""
+    sdk_version = meta.get("sdk_version") or ""
     url = meta.get("url") or meta.get("repo_url") or ""
 
     idx = safe_int(meta.get("chunk_index"))
@@ -192,6 +206,9 @@ def format_chunk_with_metadata(hit: dict) -> str:
         header_parts.append(subsection)
     if source:
         header_parts.append(f"source={source}")
+    # Surface the SDK version so the model can flag/compare version-specific code.
+    if sdk_version:
+        header_parts.append(f"sdk={sdk_version}")
     if position_label:
         header_parts.append(position_label)
     if url:
@@ -384,6 +401,17 @@ def score_hit(hit, prefs):
         if section in {"examples", "libraries", "tools", "projects"}:
             score -= 0.6
 
+        # Version-aware ranking: prefer code whose target SDK version is known
+        # (version-anchored) and down-rank clearly legacy API-era code so the
+        # assistant doesn't surface deprecated patterns as current.
+        sdk_tuple = _sdk_version_tuple(metadata.get("sdk_version"))
+        if sdk_tuple is not None:
+            score -= 0.15
+            if sdk_tuple < (0, 4):
+                score += 0.9
+            elif sdk_tuple < (0, 6):
+                score += 0.4
+
     # Favor early chunks from the same parent to avoid mid-doc orphan context.
     chunk_position = get_chunk_position(metadata)
     if chunk_position is not None:
@@ -450,6 +478,12 @@ def _reference_collection_profile(include_research_contract: bool) -> dict:
 
 
 def _is_legacy_examples_chunk(metadata: dict) -> bool:
+    # Prefer explicit SDK-version metadata when present: pre-0.4 code predates
+    # the current API surface regardless of which section it lives in.
+    sdk_tuple = _sdk_version_tuple(metadata.get("sdk_version"))
+    if sdk_tuple is not None and sdk_tuple < (0, 4):
+        return True
+
     section = (metadata.get("section") or "").lower()
     subsection = (metadata.get("subsection") or "").lower()
     title = (metadata.get("title") or "").lower()
@@ -499,6 +533,7 @@ def collect_references(ranked_hits, max_items=20, include_research_contract=True
                     "section": section,
                     "subsection": subsection,
                     "repo": repo,
+                    "sdk_version": metadata.get("sdk_version") or "",
                 },
                 max_items,
             )

--- a/src/run_all_data_ingestions.py
+++ b/src/run_all_data_ingestions.py
@@ -48,6 +48,8 @@ def run_all(force_refresh: bool = False):
         ("OZ Stylus Docs", "ingestion.data_openzeppelin_stylus_ingestion", "ingest_openzeppelin_stylus_docs"),
         ("Stylus Versions (changelog + PRs)", "ingestion.data_stylus_versions_ingestion", "ingest_stylus_versions"),
         ("Stylus Framework Code", "ingestion.data_stylus_framework_ingestion", "ingest_stylus_framework"),
+        ("Stylus By Example Code", "ingestion.data_stylus_by_example_ingestion", "ingest_stylus_by_example"),
+        ("OZ Stylus Contracts Code", "ingestion.data_openzeppelin_stylus_code_ingestion", "ingest_openzeppelin_stylus_code"),
         ("Awesome Stylus Community Code", "ingestion.data_awesome_stylus_code_ingestion", "ingest_awesome_stylus_code"),
         ("Stylus Saturdays", "ingestion.data_stylus_saturdays_ingestion", "scrape_all"),
     ]

--- a/tests/test_code_repo_utils.py
+++ b/tests/test_code_repo_utils.py
@@ -1,0 +1,196 @@
+"""Tests for SDK-version awareness in ingestion.code_repo_utils.
+
+These are the pure (no-network) building blocks that let code chunks be stamped
+with the SDK version they target, plus one injected-fetch collector test.
+"""
+
+from ingestion.code_repo_utils import (
+    _top_minor_tags,
+    collect_repo_code_entries,
+    detect_sdk_version,
+    find_cargo_toml_paths,
+    normalize_version,
+    parse_stylus_sdk_version,
+    save_code_entries,
+)
+
+
+# --------------------------------------------------------------------------
+# normalize_version
+# --------------------------------------------------------------------------
+def test_normalize_version_strips_prefixes():
+    assert normalize_version("^0.6.0") == "0.6.0"
+    assert normalize_version("~0.9") == "0.9"
+    assert normalize_version("v0.10.8") == "0.10.8"
+    assert normalize_version(">=0.5, <0.7") == "0.5"
+    assert normalize_version("  0.8.4  ") == "0.8.4"
+
+
+def test_normalize_version_handles_junk():
+    assert normalize_version("") is None
+    assert normalize_version(None) is None
+    assert normalize_version("workspace") is None
+
+
+# --------------------------------------------------------------------------
+# parse_stylus_sdk_version
+# --------------------------------------------------------------------------
+def test_parse_simple_string_dependency():
+    toml = """
+[package]
+name = "demo"
+
+[dependencies]
+stylus-sdk = "0.6.0"
+alloy-primitives = "0.7"
+"""
+    assert parse_stylus_sdk_version(toml) == "0.6.0"
+
+
+def test_parse_detailed_table_dependency():
+    toml = """
+[dependencies]
+stylus-sdk = { version = "0.9.0", features = ["export-abi"] }
+"""
+    assert parse_stylus_sdk_version(toml) == "0.9.0"
+
+
+def test_parse_underscore_crate_name():
+    toml = '[dependencies]\nstylus_sdk = "0.5.1"\n'
+    assert parse_stylus_sdk_version(toml) == "0.5.1"
+
+
+def test_parse_workspace_dependencies_table():
+    toml = """
+[workspace.dependencies]
+stylus-sdk = "0.10.0"
+"""
+    assert parse_stylus_sdk_version(toml) == "0.10.0"
+
+
+def test_parse_workspace_true_reference_is_not_a_version():
+    # A `workspace = true` member reference carries no concrete version here.
+    toml = '[dependencies]\nstylus-sdk = { workspace = true }\n'
+    assert parse_stylus_sdk_version(toml) is None
+
+
+def test_parse_regex_fallback_on_malformed_toml():
+    # Deliberately broken TOML (unclosed table) -> tomllib fails, regex saves it.
+    toml = 'oops [not valid toml\nstylus-sdk = "0.7.2"\n'
+    assert parse_stylus_sdk_version(toml) == "0.7.2"
+
+
+def test_parse_missing_dependency_returns_none():
+    assert parse_stylus_sdk_version('[dependencies]\nserde = "1.0"\n') is None
+    assert parse_stylus_sdk_version("") is None
+
+
+# --------------------------------------------------------------------------
+# find_cargo_toml_paths — root wins, then shallowest
+# --------------------------------------------------------------------------
+def test_find_cargo_toml_paths_prefers_root():
+    tree = [
+        {"type": "blob", "path": "examples/a/Cargo.toml"},
+        {"type": "blob", "path": "Cargo.toml"},
+        {"type": "blob", "path": "src/lib.rs"},
+        {"type": "tree", "path": "src"},
+        {"type": "blob", "path": "crates/x/Cargo.toml"},
+    ]
+    paths = find_cargo_toml_paths(tree)
+    assert paths[0] == "Cargo.toml"
+    assert "src/lib.rs" not in paths
+    assert set(paths) == {"Cargo.toml", "examples/a/Cargo.toml", "crates/x/Cargo.toml"}
+
+
+# --------------------------------------------------------------------------
+# detect_sdk_version — injected fetcher, root Cargo.toml wins
+# --------------------------------------------------------------------------
+def test_detect_sdk_version_uses_first_parseable_manifest():
+    tree = [
+        {"type": "blob", "path": "Cargo.toml"},
+        {"type": "blob", "path": "examples/a/Cargo.toml"},
+    ]
+    served = {
+        "https://raw.githubusercontent.com/o/r/main/Cargo.toml": "[workspace]\nmembers=[]\n",
+        "https://raw.githubusercontent.com/o/r/main/examples/a/Cargo.toml": '[dependencies]\nstylus-sdk = "0.8.0"\n',
+    }
+    version = detect_sdk_version(
+        "o/r", "main", tree, {}, fetcher=lambda url: served.get(url)
+    )
+    assert version == "0.8.0"
+
+
+# --------------------------------------------------------------------------
+# collect_repo_code_entries — stamps sdk_version, skips build artifacts
+# --------------------------------------------------------------------------
+def test_collect_repo_code_entries_stamps_version(monkeypatch):
+    import ingestion.code_repo_utils as cru
+
+    tree = [
+        {"type": "blob", "path": "src/lib.rs"},
+        {"type": "blob", "path": "target/debug/junk.rs"},  # skipped (build dir)
+        {"type": "blob", "path": "README.md"},
+        {"type": "blob", "path": "logo.png"},  # skipped (extension)
+    ]
+    monkeypatch.setattr(cru, "github_tree", lambda repo, ref, headers: tree)
+    monkeypatch.setattr(
+        cru, "fetch_text", lambda url, headers, max_bytes=200_000: f"// {url}"
+    )
+
+    entries = collect_repo_code_entries(
+        "o/r",
+        source="unit_test_code",
+        allowed_extensions=(".rs", ".md"),
+        headers={},
+        ref="main",
+        sdk_version="0.9.0",
+    )
+
+    paths = sorted(e["metadata"]["path"] for e in entries)
+    assert paths == ["README.md", "src/lib.rs"]
+    assert all(e["metadata"]["sdk_version"] == "0.9.0" for e in entries)
+    assert all(e["metadata"]["source"] == "unit_test_code" for e in entries)
+
+
+# --------------------------------------------------------------------------
+# _top_minor_tags — newest patch per minor, top N minors
+# --------------------------------------------------------------------------
+def test_top_minor_tags_picks_newest_patch_per_minor():
+    tags = ["v0.10.8", "v0.10.7", "v0.9.0", "v0.8.4", "v0.8.3", "v0.7.0"]
+    assert _top_minor_tags(tags, 3) == ["v0.10.8", "v0.9.0", "v0.8.4"]
+
+
+def test_top_minor_tags_ignores_non_semver_and_dedupes_minor():
+    tags = ["latest", "v0.9.1", "0.9.0", "nightly", "v0.8.0"]
+    assert _top_minor_tags(tags, 5) == ["v0.9.1", "v0.8.0"]
+
+
+# --------------------------------------------------------------------------
+# save_code_entries — multi-version keys coexist; window prune drops rolled-off
+# --------------------------------------------------------------------------
+def test_save_code_entries_multi_version_prunes_outside_window(tmp_path, monkeypatch):
+    import ingestion.incremental_utils as iu
+
+    monkeypatch.setattr(iu, "INGESTION_STATS_PATH", str(tmp_path / "stats.json"))
+    out = str(tmp_path / "framework.json")
+
+    def entry(ref, version, path):
+        return {
+            "text": f"{ref}:{path}",
+            "metadata": {"repo": "o/r", "ref": ref, "sdk_version": version, "path": path},
+        }
+
+    # Two versions of the same path must coexist under multi_version keys.
+    first = [entry("v0.9.0", "0.9.0", "src/lib.rs"), entry("v0.8.0", "0.8.0", "src/lib.rs")]
+    merged = save_code_entries(out, first, "framework_test", multi_version=True,
+                               keep_refs={"v0.9.0", "v0.8.0"})
+    versions = {e["metadata"]["sdk_version"] for e in merged}
+    assert versions == {"0.8.0", "0.9.0"}
+
+    # New run: 0.10 arrives, 0.8 rolls off the window -> pruned, 0.9 carried.
+    second = [entry("v0.10.0", "0.10.0", "src/lib.rs"), entry("v0.9.0", "0.9.0", "src/lib.rs")]
+    merged = save_code_entries(out, second, "framework_test", multi_version=True,
+                               keep_refs={"v0.10.0", "v0.9.0"})
+    versions = {e["metadata"]["sdk_version"] for e in merged}
+    assert versions == {"0.9.0", "0.10.0"}
+    assert "0.8.0" not in versions

--- a/tests/test_retrieve_chroma_docs_scoring.py
+++ b/tests/test_retrieve_chroma_docs_scoring.py
@@ -45,6 +45,55 @@ def test_score_hit_code_request_prefers_repo_examples_over_docs():
     assert repo_score < docs_score
 
 
+def test_score_hit_code_request_downranks_legacy_sdk_version():
+    base_meta = {"source": "stylus_framework_code", "section": "", "repo": "o/r"}
+    current = {"text": "impl contract", "metadata": {**base_meta, "sdk_version": "0.9.0"}, "distance": 0.2}
+    legacy = {"text": "impl contract", "metadata": {**base_meta, "sdk_version": "0.3.0"}, "distance": 0.2}
+    prefs = retrieval.get_query_preferences("show me a stylus contract", code_request=True)
+
+    # Lower score is better; current-version code should outrank legacy code.
+    assert retrieval.score_hit(current, prefs) < retrieval.score_hit(legacy, prefs)
+
+
+def test_score_hit_prefers_version_anchored_code():
+    meta = {"source": "awesome_stylus_code", "section": "", "repo": "o/r"}
+    anchored = {"text": "impl contract", "metadata": {**meta, "sdk_version": "0.9.0"}, "distance": 0.2}
+    unknown = {"text": "impl contract", "metadata": dict(meta), "distance": 0.2}
+    prefs = retrieval.get_query_preferences("stylus contract code", code_request=True)
+
+    assert retrieval.score_hit(anchored, prefs) < retrieval.score_hit(unknown, prefs)
+
+
+def test_format_chunk_surfaces_sdk_version():
+    hit = {
+        "text": "fn main() {}",
+        "metadata": {
+            "title": "lib.rs",
+            "source": "stylus_framework_code",
+            "sdk_version": "0.9.0",
+            "url": "https://raw.githubusercontent.com/o/r/v0.9.0/src/lib.rs",
+        },
+    }
+    formatted = retrieval.format_chunk_with_metadata(hit)
+    assert "sdk=0.9.0" in formatted
+
+
+def test_collect_references_carries_sdk_version():
+    ranked_hits = [
+        {
+            "text": "impl contract",
+            "metadata": {
+                "title": "erc20.rs",
+                "url": "https://github.com/OpenZeppelin/rust-contracts-stylus",
+                "source": "openzeppelin_stylus_code",
+                "sdk_version": "0.2.0",
+            },
+        }
+    ]
+    refs = retrieval.collect_references(ranked_hits, max_items=5)
+    assert refs and refs[0]["sdk_version"] == "0.2.0"
+
+
 def test_collect_references_includes_inline_and_plain_urls_and_filters_local():
     ranked_hits = [
         {


### PR DESCRIPTION


Code was captured at moving main/master HEAD with no version identity, so the assistant could not distinguish SDK versions and mixed old-API community code with current SDK code. This adds version anchoring and corpus quality gates.

- Add ingestion/code_repo_utils.py: shared GitHub tree/file fetch, repo metadata, latest-release / last-N-minor-release resolution, and pure Cargo.toml -> stylus-sdk version parsing; stamps sdk_version on code chunks.
- Framework: keep the last 3 minor stylus-sdk-rs releases side-by-side (env STYLUS_SDK_KEEP_MINORS), each stamped with its own sdk_version; prune versions that roll off the window.
- Community (awesome): parse each repo's Cargo.toml for sdk_version; drop archived/low-star/stale repos (logged, not silent); restrict to .rs/.toml/.md.
- New sources: stylus-by-example repo and OpenZeppelin rust-contracts-stylus (release-pinned) contract source, both version-stamped.
- Retrieval: surface sdk_version in the context header and citations; make code-request ranking prefer version-anchored chunks and down-rank legacy pre-0.6 (skip pre-0.4) API-era code.
- Wire new jobs into run_all; document version behavior in ingestion README.
- Tests for version parsing, minor-release selection, multi-version prune, and version-aware retrieval surfacing/ranking.